### PR TITLE
add triple curly brackets {{{color}}} to support color fill

### DIFF
--- a/Sketch Data Populator.sketchplugin/Contents/Sketch/plugin.cocoascript
+++ b/Sketch Data Populator.sketchplugin/Contents/Sketch/plugin.cocoascript
@@ -468,7 +468,8 @@ function populate(data, selectedLayers, opt) {
 				});
 
 				//find icon and image placeholders
-				var iconPlaceholders = Library.findLayersInLayer('{{*}}', false, 'MSShapeGroup', selectedLayer, false, false);
+				var colorPlaceholders = Library.findLayersInLayer('{{{*}}}', false, 'MSShapeGroup', selectedLayer, false, false);
+				var iconPlaceholders = Library.findLayersInLayer('{{*}}', false, 'MSShapeGroup', selectedLayer, false, colorPlaceholders);
 				var imagePlaceholders = Library.findLayersInLayer('{*}', false, 'MSShapeGroup', selectedLayer, false, iconPlaceholders);
 
 				//process all image placeholders
@@ -480,6 +481,11 @@ function populate(data, selectedLayers, opt) {
 				iconPlaceholders.forEach(function(shapeGroup) {
 					processIconPlaceholder(shapeGroup, dataRow, opt.rootDir);
 					svgIconsStartedImport++;
+				});
+
+				//process all color placeholders
+				colorPlaceholders.forEach(function(shapeGroup) {
+					processColorPlaceholder(shapeGroup, dataRow, opt.rootDir);
 				});
 			}
 			else if(Library.isLayerText(selectedLayer)) {
@@ -892,6 +898,43 @@ function populate(data, selectedLayers, opt) {
 		else {
 			svgIconsImported++;
 		}
+	}
+
+	function processColorPlaceholder(shapeGroup, dataRow, rootDir) {
+
+		//get shape group name
+		var shapeGroupName = [shapeGroup name].toString();
+		log(shapeGroupName);
+
+		//get placeholder name
+		var placeholder = shapeGroupName.substring(3, [shapeGroupName length] - 3);
+		log(placeholder);
+
+		//get hex color for placeholder from data row
+		var hexColor = dataRow[placeholder];
+		log(hexColor);
+
+		if(!hexColor) {
+			//hide placeholder
+			shapeGroup.setIsVisible(false);
+			return;
+		}
+		else {
+			//show placeholder
+			shapeGroup.setIsVisible(true);
+		}
+
+		//get shape group fill
+		var fill = [[[shapeGroup style] fills] firstObject];
+
+		//enable fill
+		fill.setIsEnabled(true);
+
+		//set pattern fill
+		fill.setFillType(0);
+
+		// set the color
+		fill.color = [MSColor colorWithSVGString:hexColor];
 	}
 
 

--- a/Sketch Data Populator.sketchplugin/Contents/Sketch/plugin.cocoascript
+++ b/Sketch Data Populator.sketchplugin/Contents/Sketch/plugin.cocoascript
@@ -199,7 +199,7 @@ function populateWithJSONHandler(_context) {
 	//get JSON file path
 	var filePath = Library.askForJSON(lastLocation);
 	if(!filePath) return;
-	
+
 	//save last used location
 	[defaults setObject: filePath forKey: 'LastJSONFilePickerLocation'];
 	[defaults synchronize];
@@ -541,10 +541,10 @@ function populate(data, selectedLayers, opt) {
 		//assign values to placeholders
 		var values = {};
 		placeholders.forEach(function(placeholder) {
-			
+
 			//solo/default placeholder
 			if(placeholder.type == 'solo') {
-				
+
 				//get value
 				var value = dataRow[placeholder.key];
 
@@ -566,11 +566,11 @@ function populate(data, selectedLayers, opt) {
 				values[placeholder.string] = value;
 			}
 			else if(placeholder.type == 'enum') {
-				
+
 				//get values for sub placeholders
 				var placeholderValues = [];
 				placeholder.placeholders.forEach(function(subPlaceholder) {
-					
+
 					//get value
 					var value = dataRow[subPlaceholder.key];
 
@@ -588,17 +588,17 @@ function populate(data, selectedLayers, opt) {
 							value = '';
 						}
 					}
-					
+
 					//make sure value is not empty
 					if(value.length) placeholderValues.push(value);
 				});
-				
+
 				//prepare enumerated value
 				var enumeratedValue = '';
 				if(placeholder.command == 'join') {
 					enumeratedValue = placeholderValues.join(placeholder.delimiter);
 				}
-				
+
 				values[placeholder.string] = enumeratedValue;
 			}
 		});
@@ -904,15 +904,12 @@ function populate(data, selectedLayers, opt) {
 
 		//get shape group name
 		var shapeGroupName = [shapeGroup name].toString();
-		log(shapeGroupName);
 
 		//get placeholder name
 		var placeholder = shapeGroupName.substring(3, [shapeGroupName length] - 3);
-		log(placeholder);
 
 		//get hex color for placeholder from data row
 		var hexColor = dataRow[placeholder];
-		log(hexColor);
 
 		if(!hexColor) {
 			//hide placeholder
@@ -952,27 +949,27 @@ function populate(data, selectedLayers, opt) {
 
 	  		//get inside of placeholder (between {})
 	  		var placeholderText = text[1];
-	  		
+
 	  		//check if placeholder uses enumeration syntax
 	  		if(placeholderText.indexOf('|&') > -1) {
-	  			
+
 	  			//split enum placeholder text into components
 	  			var placeholderComponents = placeholderText.split('|&');
-	  			
+
 	  			//get placeholders
 	  			var placeholdersString = placeholderComponents[0] || '';
 	  			var placeholderStrings = placeholdersString.split(',');
 	  			var placeholders = [];
 	  			placeholderStrings.forEach(function(placeholderString) {
-	  				
+
 	  				//process placeholder string
 	  				var placeholder = processPlaceholderString(placeholderString.trim());
 	  				placeholders.push(placeholder);
 	  			});
-	  			
+
 	  			//get delimiter
 	  			var delimiter = placeholderComponents[1] || '';
-	  			
+
 	  			//create object
 	  			results.push({
 	  				string: placeholderText,
@@ -983,16 +980,16 @@ function populate(data, selectedLayers, opt) {
 	  			});
 	  		}
 	  		else {
-	  			
+
 	  			//process placeholder text
 	  			var placeholder = processPlaceholderString(placeholderText);
 	  			results.push(placeholder);
 	  		}
 	  	}
-	  	
-	  	
+
+
 	  	function processPlaceholderString(placeholderString) {
-	  			
+
   			//split into components
   			var placeholderComponents = placeholderString.split('?');
 
@@ -1030,7 +1027,7 @@ function populate(data, selectedLayers, opt) {
 
 
 function createGrid(selectedLayers, opt) {
-	
+
 	//check rows count
 	if(!opt.rowsCount || opt.rowsCount < 0) {
 		context.document.showMessage('Number of grid rows must be at least 1.');


### PR DESCRIPTION
For example, we have a binding `{{{brandColor}}}`, and we can put `"brandColor": "#333333"` to set the color fill.