### PR TITLE
Temporarily disable fill pattern type

### DIFF
--- a/src/library/populator.js
+++ b/src/library/populator.js
@@ -1003,7 +1003,7 @@ function populateImageLayer(layer, data, opt) {
 
   //set fill properties
   fill.setFillType(4)
-  fill.setPatternFillType(1)
+  // fill.setPatternFillType(1)
 
   //set image as an override for image layer within a symbol
   if (inSymbol) {


### PR DESCRIPTION
Just a quick fix to respect the image layer's property of pattern fill type.