### PR TITLE
Fix `#plugin` action not working in modern versions of Sketch

### DIFF
--- a/sketch/src/sketch/actions/plugin.js
+++ b/sketch/src/sketch/actions/plugin.js
@@ -69,7 +69,11 @@ export function perform(condition, layer, params) {
   setCommandParamsToMetadata(layer, params)
 
   // run the command
-  NSApp.delegate().runPluginCommand(command)
+  if (NSApp.delegate().runPluginCommand_fromMenu_context_) {
+    NSApp.delegate().runPluginCommand_fromMenu_context_(command, null, {})
+  } else {
+    throw new Error("The current version of Sketch is not supported.")
+  }
 
   // remove params
   removeCommandParamsFromMetadata(layer)


### PR DESCRIPTION
Getting this action working again is key to unlock workflows like this one: https://forum.sketch.com/t/populate-color-from-json-file/2465

-----

P.S. The official documentation lacks practical examples so here's how the `#plugin` action is supposed to be used:

1. Let's say you have the following plugin installed that you want to invoke on one of your template layers based on some condition:
   <img width="294" alt="Screenshot 2024-02-16 at 13 54 14" src="https://github.com/dataliterate/data-populator/assets/5719520/9df04155-a656-4bf4-b08e-9b3e24c506a4">

2. Let's also assume that you have the following template layer structure:
   <img width="418" alt="Screenshot 2024-02-16 at 13 56 10" src="https://github.com/dataliterate/data-populator/assets/5719520/c3601735-d6a4-46d9-9408-92c6e0d8dc3f">

3. Now, to invoke the plugin on the Rectangle layer, rename the latter as follows:
   ```
   #plugin[{condition}, My Plugin > My Action]
   ```
   <img width="323" alt="Screenshot 2024-02-16 at 13 59 01" src="https://github.com/dataliterate/data-populator/assets/5719520/50d1962f-8653-4904-8685-1516636789c6">

   > ℹ️ There're no quotation marks around the plugin command path.
   > ℹ️ You may only invoke single-level commands, so things like `My Plugin > Group > My Action` won't work).

### Notes

- Your `{condition}` might be as simple as just `true` (e.g. `#plugin[true, My Plugin > My Action]`) if you want to always invoke the plugin no matter what's in your data. It may also reference other variables in your data: [see examples](https://www.datapopulator.com/documentation/#available-actions).
- You may pass arguments to a plugin by including them in a layer name:
   ```
   #plugin[{condition}, My Plugin > My Action, arg1, arg2 {zip_code}, arg3]
   ```

   > ℹ️ The `{zip_code}` placeholder in the example above will be replaced with an actual value from your data just like any other placeholder).

   In order to access those arguments in your plugin, use the following:
   ```javascript
   // in script.js
   
   const util = require('util')
   var onRun = function (context) {
      let arguments = util.toArray(context.selection[0].userInfo()["datapopulator"]).map(String)
      // arguments == ["arg1", "arg2 {94024}", "arg3"]
   }
   ```
   As you can see, argument are passed to the plugin as an array of strings.
   > ⚠️ Don't forget to use `util.toArray()` and the `map` bit to convert it to a proper JavaScript array of Strings.